### PR TITLE
feat: Enhance ComparisonTable with new change metrics and table

### DIFF
--- a/src/data/locales/en/analysis.json
+++ b/src/data/locales/en/analysis.json
@@ -40,6 +40,8 @@
     "noChange": "No change",
     "worse": "Deteriorating",
     "better": "Improving",
-    "nA": "N/A"
+    "nA": "N/A",
+    "analysisOfChange": "Analysis of Change",
+    "zoneChangeHeader": "Analyzed Zones Change",
+    "populationChangeHeader": "Analyzed Population Change"
   }
-  

--- a/src/data/locales/fr/analysis.json
+++ b/src/data/locales/fr/analysis.json
@@ -40,6 +40,8 @@
     "change": "Changement",
     "noChange": "Pas de changement",
     "worse": "Détérioration",
-    "better": "Amélioration"
+    "better": "Amélioration",
+    "analysisOfChange": "Analyse des Évolutions",
+    "zoneChangeHeader": "Évolution Zones Analysées",
+    "populationChangeHeader": "Évolution Population Analysée"
   }
-  


### PR DESCRIPTION
This commit implements several enhancements to the ComparisonTable component:

1.  New Change Metrics:
    - Introduces "Change in Analyzed Zones," calculating the difference in the number of Admin2 zones analyzed between two periods.
    - Introduces "Change in Analyzed Population," calculating the difference in the total population of analyzed zones between two periods.

2.  Revised Data Aggregation (`aggregateFeatures`):
    - Refactored the core aggregation logic to accurately sum populations and count Admin2 zones, especially when dealing with data where analysis was performed at Admin1 level (`matchLevel: 1`). The function now correctly uses all relevant Admin2 features for calculations in these scenarios, rather than relying on potentially inaccurate single representative features per Admin1 area.
    - `numberOfAnalyzedUnits` now correctly reflects the count of Admin2s.

3.  UI Update - Fourth Table for Changes:
    - Removed the previous "Change" column (based on classification severity) from the third table.
    - Added a new fourth table to display the "Change in Analyzed Zones" and "Change in Analyzed Population."

4.  Visual Indicators for Change:
    - The new change metrics are displayed with: - Upward (▲) or downward (▼) arrows indicating the direction. - Green text for positive changes, red for negative.

5.  Comprehensive Updates:
    - Ensured that Admin1 sub-row expansions also reflect these new change calculations and visual styles.
    - Added necessary translations for new UI elements in English and French.