### PR TITLE
feat: Implement Ph3+ changes, Admin1-Admin2 expansion, and conditiona…

### DIFF
--- a/src/data/locales/en/analysis.json
+++ b/src/data/locales/en/analysis.json
@@ -42,6 +42,8 @@
     "better": "Improving",
     "nA": "N/A",
     "analysisOfChange": "Analysis of Change",
-    "zoneChangeHeader": "Analyzed Zones Change",
-    "populationChangeHeader": "Analyzed Population Change"
+    "zoneChangeHeader": "Change in Ph3+ Zones",
+    "populationChangeHeader": "Change in Ph3+ Population",
+    "loadingAdmin1Data": "Loading Admin1 data...",
+    "loadingAdmin2Data": "Loading Admin2 data..."
   }

--- a/src/data/locales/fr/analysis.json
+++ b/src/data/locales/fr/analysis.json
@@ -42,6 +42,8 @@
     "worse": "Détérioration",
     "better": "Amélioration",
     "analysisOfChange": "Analyse des Évolutions",
-    "zoneChangeHeader": "Évolution Zones Analysées",
-    "populationChangeHeader": "Évolution Population Analysée"
+    "zoneChangeHeader": "Évol. Zones Ph3+",
+    "populationChangeHeader": "Évol. Pop. Ph3+",
+    "loadingAdmin1Data": "Chargement données Admin1...",
+    "loadingAdmin2Data": "Chargement données Admin2..."
   }

--- a/src/styles/ComparisonTable.css
+++ b/src/styles/ComparisonTable.css
@@ -259,9 +259,11 @@
   overflow: visible;
 }
 
+/* Indentation for Admin1 and Admin2 rows */
+.comparison-table tbody tr.admin1-row > td:first-child {
+  padding-left: 20px;
+}
 
-/* Add this to ComparisonTable.css */
-
-.admin1-row td:first-child {
-  padding-left: 40px;  /* or 25px, 30px—whatever indentation you prefer */
+.comparison-table tbody tr.admin2-row > td:first-child {
+  padding-left: 40px;
 }


### PR DESCRIPTION
…l classification

This commit introduces major updates to the ComparisonTable component:

1.  Phase 3+ Specific Change Calculations:
    - Population Change: Now calculated based on the difference in population in Phase 3 and above ("Population totale en Ph 3 à 5") between periods. Displayed in thousands.
    - Zone Change: Now calculated based on the difference in the number of Admin2 zones classified as "Phase 3 : crises" or worse between periods.
    - `aggregateFeatures` updated to return `rawPh3Pop` and `numberOfZonesInPh3Plus`.

2.  Admin1 to Admin2 Row Expansion:
    - You can now click on Admin1 level rows to expand them and view data for their constituent Admin2 zones.
    - Implemented state management for Admin1 expansion, data fetching and caching for Admin2 sub-rows (`getAdmin2DataForAdmin1`), and updated display logic to render the hierarchical table.
    - Includes loading indicators for Admin2 data.

3.  Conditional Classification Column Visibility:
    - The "Classification" column in the Period 1 and Period 2 data tables is now conditionally displayed: - Hidden for Admin0 level rows. - Hidden for Admin1 level rows, *unless* their data is specifically marked as an Admin1 aggregation (`row.aggregatedAtAdmin1`). - Always shown for Admin2 level rows.
    - Empty cells are rendered when classification is hidden to maintain table alignment.

4.  UI and Styling:
    - Added CSS for visual indentation of Admin1 and Admin2 sub-rows.
    - Updated translation keys for table headers to reflect the Ph3+ context of change metrics and added new keys for loading messages.

These changes address specific requirements from you for more detailed analysis focusing on Phase 3+ conditions and deeper data drill-down capabilities.