### PR TITLE
fix: Adjust table expansion, classification visibility, and change co…

### DIFF
--- a/src/data/locales/en/analysis.json
+++ b/src/data/locales/en/analysis.json
@@ -46,5 +46,4 @@
     "populationChangeHeader": "Change in Ph3+ Population",
     "loadingAdmin1Data": "Loading Admin1 data...",
     "loadingAdmin2Data": "Loading Admin2 data..."
-
   }


### PR DESCRIPTION
…lors

This commit implements several adjustments based on your feedback:

1.  Inverted Change Visual Colors:
    - The `getChangeVisuals` helper function has been modified. An increase in Phase 3+ zones or population (positive change value) is now displayed in red (indicating a negative outcome), and a decrease (negative change value) is displayed in green (positive outcome). Neutral changes remain default.

2.  Conditional Admin1-to-Admin2 Expansion:
    - Admin1 level rows are now only expandable to show Admin2 level data if the Admin1 row's data for Period 1 is not pre-aggregated (i.e., `row.aggregated1` is false).
    - Expansion controls (`+/-` indicators, click handlers) are now conditionally rendered for Admin1 rows based on this logic.

3.  Refined Classification Column Visibility:
    - The "Classification" column in data tables is now shown only for the "last available administrative level": - Always shown for Admin2 rows. - For Admin1 rows, shown only if the row represents an aggregated endpoint (i.e., its Period 1 data is aggregated, or Period 1 is N/A and Period 2 data is aggregated). It's hidden for Admin1 rows that are expandable to Admin2. - Always hidden for Admin0 rows.
    - This ensures classification is displayed appropriately based on the data's granularity and expansion state.