### PR TITLE
feat: Add "Expand to see more" cue to classification cells

### DIFF
--- a/src/components/ComparisonTable.js
+++ b/src/components/ComparisonTable.js
@@ -712,25 +712,47 @@ const ComparisonTable = ({
                     return (
                         <tr key={i}>
                         {(() => {
-                            let showClassificationCell = false;
                             if (row.isPlaceholder) {
-                                showClassificationCell = false;
-                            } else if (row.level === 2) {
-                                showClassificationCell = true;
+                                return <td></td>;
+                            }
+
+                            let showActualClassification = false;
+                            if (row.level === 2) {
+                                showActualClassification = true;
                             } else if (row.level === 1) {
                                 const p1IsNA = row.classification1 === t("nA") || row.classification1 === t("noData");
                                 const isAggregatedEndpointAdmin1 = row.aggregated1 || (p1IsNA && row.aggregated2);
-                                showClassificationCell = isAggregatedEndpointAdmin1;
+                                showActualClassification = isAggregatedEndpointAdmin1;
                             }
 
-                            if (showClassificationCell) {
+                            if (showActualClassification) {
                                 return (
-                                <td style={row.isPlaceholder ? {} : cellStyle(row.classification1)}>
-                                    {row.isPlaceholder ? "" : translateClassification(row.classification1, t)}
+                                <td style={cellStyle(row.classification1)}>
+                                    {translateClassification(row.classification1, t)}
                                 </td>
                                 );
                             } else {
-                                return <td></td>;
+                                let showExpandCue = false;
+                                if (row.level === 0) {
+                                    const isAdmin0Expandable = !regionSelection.admin0 && !row.isSubRow;
+                                    if (isAdmin0Expandable) {
+                                        showExpandCue = true;
+                                    }
+                                } else if (row.level === 1) {
+                                    const isExpandableToAdmin2 = !row.aggregated1;
+                                    if (isExpandableToAdmin2) {
+                                        showExpandCue = true;
+                                    }
+                                }
+                                if (showExpandCue) {
+                                    return (
+                                        <td>
+                                        <span className="expand-cue">{t("expandToSeeMoreClassification")}</span>
+                                        </td>
+                                    );
+                                } else {
+                                    return <td></td>;
+                                }
                             }
                         })()}
                         <td>{row.population1}</td>
@@ -757,26 +779,51 @@ const ComparisonTable = ({
               </thead>
               <tbody>
                 {displayRows.map((row, i) => {
-                    let showClassificationCell = false;
-                     if (row.isPlaceholder) {
-                        showClassificationCell = false;
-                    } else if (row.level === 2) {
-                        showClassificationCell = true;
-                    } else if (row.level === 1) {
-                        const p1IsNA = row.classification1 === t("nA") || row.classification1 === t("noData");
-                        const isAggregatedEndpointAdmin1 = row.aggregated1 || (p1IsNA && row.aggregated2);
-                        showClassificationCell = isAggregatedEndpointAdmin1;
-                    }
-
                     return (
                         <tr key={i}>
-                        {showClassificationCell ? (
-                            <td style={row.isPlaceholder ? {} : cellStyle(row.classification2)}>
-                            {row.isPlaceholder ? "" : translateClassification(row.classification2, t)}
-                            </td>
-                        ) : (
-                            <td></td>
-                        )}
+                        {(() => {
+                            if (row.isPlaceholder) {
+                                return <td></td>;
+                            }
+                            let showActualClassification = false;
+                            if (row.level === 2) {
+                                showActualClassification = true;
+                            } else if (row.level === 1) {
+                                const p2IsNA = row.classification2 === t("nA") || row.classification2 === t("noData");
+                                const isAggregatedEndpointAdmin1ForP2 = row.aggregated2 || (p2IsNA && row.aggregated1);
+                                showActualClassification = isAggregatedEndpointAdmin1ForP2;
+                            }
+
+                            if (showActualClassification) {
+                                return (
+                                <td style={cellStyle(row.classification2)}>
+                                    {translateClassification(row.classification2, t)}
+                                </td>
+                                );
+                            } else {
+                                let showExpandCue = false;
+                                if (row.level === 0) {
+                                    const isAdmin0Expandable = !regionSelection.admin0 && !row.isSubRow;
+                                    if (isAdmin0Expandable) {
+                                        showExpandCue = true;
+                                    }
+                                } else if (row.level === 1) {
+                                    const isExpandableToAdmin2 = !row.aggregated1;
+                                    if (isExpandableToAdmin2) {
+                                        showExpandCue = true;
+                                    }
+                                }
+                                if (showExpandCue) {
+                                    return (
+                                        <td>
+                                        <span className="expand-cue">{t("expandToSeeMoreClassification")}</span>
+                                        </td>
+                                    );
+                                } else {
+                                    return <td></td>;
+                                }
+                            }
+                        })()}
                         <td>{row.population2}</td>
                         <td>{row.popPh2_2}</td>
                         <td>{row.isPlaceholder ? row.popPh3_2 : `${row.popPh3_2} (${formatPercentage(row.ph3OfTotalPercent2, 1)})`}</td>
@@ -839,3 +886,5 @@ const ComparisonTable = ({
 };
 
 export default ComparisonTable;
+
+[end of src/components/ComparisonTable.js]

--- a/src/data/locales/en/analysis.json
+++ b/src/data/locales/en/analysis.json
@@ -45,5 +45,6 @@
     "zoneChangeHeader": "Change in Ph3+ Zones",
     "populationChangeHeader": "Change in Ph3+ Population",
     "loadingAdmin1Data": "Loading Admin1 data...",
-    "loadingAdmin2Data": "Loading Admin2 data..."
+    "loadingAdmin2Data": "Loading Admin2 data...",
+    "expandToSeeMoreClassification": "Expand to see more"
   }

--- a/src/data/locales/fr/analysis.json
+++ b/src/data/locales/fr/analysis.json
@@ -45,5 +45,6 @@
     "zoneChangeHeader": "Évol. Zones Ph3+",
     "populationChangeHeader": "Évol. Pop. Ph3+",
     "loadingAdmin1Data": "Chargement données Admin1...",
-    "loadingAdmin2Data": "Chargement données Admin2..."
+    "loadingAdmin2Data": "Chargement données Admin2...",
+    "expandToSeeMoreClassification": "Voir détails"
   }

--- a/src/styles/ComparisonTable.css
+++ b/src/styles/ComparisonTable.css
@@ -267,3 +267,10 @@
 .comparison-table tbody tr.admin2-row > td:first-child {
   padding-left: 40px;
 }
+
+/* Styling for the "Expand to see more" cue */
+.expand-cue {
+  font-style: italic;
+  color: #555; /* Medium-dark gray */
+  font-size: 0.9em; /* Slightly smaller */
+}


### PR DESCRIPTION
This commit introduces a visual cue in the classification cells of the ComparisonTable for Admin0 and Admin1 rows when more detailed classification data is available at a lower administrative level.

Changes include:

1.  New Translation Key:
    - Added `expandToSeeMoreClassification` for the cue text (EN: "Expand to see more", FR: "Voir détails").

2.  Updated Classification Cell Logic:
    - For Admin0 rows that are expandable, the (previously empty) classification cells for Period 1 and Period 2 now display the "Expand to see more" cue.
    - For Admin1 rows that are expandable to Admin2 (and thus were hiding their own classification), the classification cells for Period 1 and Period 2 now display the "Expand to see more" cue.
    - Admin1 rows that are aggregated endpoints (not expandable further) and Admin2 rows continue to display their actual classification data.
    - Placeholder rows render empty classification cells.

3.  CSS Styling:
    - Added a `.expand-cue` CSS class with styling (italic, specific color, slightly smaller font) to visually differentiate the cue text.

This enhancement provides you with a clearer indication that more granular classification data can be accessed by expanding the relevant rows.