### PR TITLE
Refine country maps: visibility, zoom, prompts, tooltips

### DIFF
--- a/src/pages/Analysis.js
+++ b/src/pages/Analysis.js
@@ -85,24 +85,37 @@ export default function Analysis() {
                     onSelect={setSelectedRegionData}
                   />
                   {/* Conditional rendering of CountryMapView components */}
-                  {getCurrentAdminLevel(selectedRegionData.region) === "admin0" && selectedRegionData.region.admin0 && selectedRegionData.period1 && selectedRegionData.period2 && geojsonFeatures.length > 0 && (
-                    <div className="country-maps-container" style={{ display: 'flex', justifyContent: 'space-around', margin: '20px 0' }}>
-                      <div style={{ width: '48%' }}> {/* Adjusted width for better spacing */}
-                        <CountryMapView
-                          country={selectedRegionData.region.admin0}
-                          period={selectedRegionData.period1}
-                          data={geojsonFeatures}
-                        />
+                  {selectedRegionData.period1 && selectedRegionData.period2 && geojsonFeatures.length > 0 ? (
+                    selectedRegionData.region.admin0 ? (
+                      <div className="country-maps-container" style={{ display: 'flex', justifyContent: 'space-around', margin: '20px 0' }}>
+                        <div style={{ width: '48%' }}>
+                          <CountryMapView
+                            country={selectedRegionData.region.admin0}
+                            currentPeriod={selectedRegionData.period1}
+                            otherPeriod={selectedRegionData.period2}
+                            data={geojsonFeatures}
+                          />
+                        </div>
+                        <div style={{ width: '48%' }}>
+                          <CountryMapView
+                            country={selectedRegionData.region.admin0}
+                            currentPeriod={selectedRegionData.period2}
+                            otherPeriod={selectedRegionData.period1}
+                            data={geojsonFeatures}
+                          />
+                        </div>
                       </div>
-                      <div style={{ width: '48%' }}> {/* Adjusted width for better spacing */}
-                        <CountryMapView
-                          country={selectedRegionData.region.admin0}
-                          period={selectedRegionData.period2}
-                          data={geojsonFeatures}
-                        />
+                    ) : (
+                      <div className="country-maps-container" style={{ display: 'flex', justifyContent: 'space-around', margin: '20px 0' }}>
+                        <div className="country-map-placeholder" style={{ width: '48%', height: '400px', display: 'flex', alignItems: 'center', justifyContent: 'center', border: '1px dashed #ccc', backgroundColor: '#f9f9f9' }}>
+                          <p>{t("selectCountryPrompt")}</p>
+                        </div>
+                        <div className="country-map-placeholder" style={{ width: '48%', height: '400px', display: 'flex', alignItems: 'center', justifyContent: 'center', border: '1px dashed #ccc', backgroundColor: '#f9f9f9' }}>
+                          <p>{t("selectCountryPrompt")}</p>
+                        </div>
                       </div>
-                    </div>
-                  )}
+                    )
+                  ) : null}
                   <ComparisonTable
                     regionSelection={selectedRegionData.region}
                     period1={selectedRegionData.period1}

--- a/src/styles/CountryMapView.css
+++ b/src/styles/CountryMapView.css
@@ -46,3 +46,42 @@
     margin-bottom: 5px;
   }
 }
+
+/* Tooltip styling for CountryMapView */
+.country-map-view .custom-popup .mapboxgl-popup-content {
+  font-size: 10px; /* Smaller base font size */
+  padding: 5px 8px;
+  max-width: 220px; /* Adjust as needed */
+  background-color: rgba(255, 255, 255, 0.95); /* Slightly more opaque */
+}
+
+.country-map-view .custom-popup .popup-header {
+  font-size: 11px; /* Slightly smaller header */
+  margin-bottom: 3px;
+}
+
+.country-map-view .custom-popup .popup-subheader {
+  font-size: 10px; /* Smaller subheader */
+  padding: 2px 4px;
+  margin-bottom: 4px;
+}
+
+.country-map-view .custom-popup .popup-details table {
+  font-size: 9px; /* Even smaller for table content */
+  line-height: 1.3;
+}
+
+.country-map-view .custom-popup .popup-details table th,
+.country-map-view .custom-popup .popup-details table td {
+  padding: 1px 3px; /* Reduced padding */
+}
+
+.country-map-view .custom-popup .popup-aggregated {
+  font-size: 9px;
+  padding: 2px;
+}
+
+.country-map-view .custom-popup .popup-flag img {
+  width: 20px; /* Smaller flag */
+  height: auto;
+}


### PR DESCRIPTION
This commit introduces several improvements to the country comparison maps feature in the Analysis page:

1.  **Map Visibility**: Country maps now remain visible if an admin0 (country) is selected, even when admin1 or admin2 regions are subsequently chosen.
2.  **Zoom/Coordinate Adjustments**: Implemented increased default padding for map `fitBounds` and applied specific `maxZoom` values for Guinea-Bissau (GNB) and Côte d'Ivoire (CIV) to mitigate overzooming issues.
3.  **No-Country Prompt**: If no country is selected, placeholder areas now display a prompt asking the user to select a country to view the maps.
4.  **Tooltip Enhancements for CountryMapView**:
    *   **Content Parity**: Tooltips now display information consistent with the main `MapView.js` (admin names, flag, classification, population figures, aggregated data notice).
    *   **Difference Data**: Tooltips show the difference in population figures between the two selected periods for the hovered administrative unit.
    *   **Styling**: Applied CSS to reduce font sizes and padding in tooltips for a more compact appearance suitable for the smaller map windows.

Updated `CountryMapView.js` to use `currentPeriod` and `otherPeriod` props for clarity and to support difference calculations. Noted the need for new i18n translation keys: `selectCountryPrompt`, `indicator`, `difference`.