### PR TITLE
Refine: Enhance Country Map Tooltips

### DIFF
--- a/src/styles/CountryMapView.css
+++ b/src/styles/CountryMapView.css
@@ -67,13 +67,19 @@
 }
 
 .country-map-view .custom-popup .popup-details table {
-  font-size: 9px; /* Even smaller for table content */
-  line-height: 1.3;
+  font-size: 8px; /* Further reduced font size for table content */
+  line-height: 1.2; /* Slightly tighter line height */
+  font-weight: normal; /* Ensure table content is not bold by default */
 }
 
-.country-map-view .custom-popup .popup-details table th,
 .country-map-view .custom-popup .popup-details table td {
-  padding: 1px 3px; /* Reduced padding */
+  padding: 1px 2px; /* Further reduced padding */
+  font-weight: normal; /* Ensure td content is not bold */
+}
+
+/* Make the first column (indicator names) bold again if desired, or specific parts like "Total Pop." */
+.country-map-view .custom-popup .popup-details table td:first-child strong {
+  font-weight: bold; /* Keep indicator names bold */
 }
 
 .country-map-view .custom-popup .popup-aggregated {


### PR DESCRIPTION
This commit further enhances the tooltips in the CountryMapView component:

1.  **Classification Change Indicator:**
    *   Added a visual indicator (e.g., "(Better)", "(Worse)") with corresponding green/red font color next to the current period's classification if it has changed compared to the other selected period.
    *   Handles cases where analysis status changes (e.g., "(Now Analyzed)").
    *   A helper function `getPhaseNumber` was implemented to convert classification strings to numerical values for comparison.

2.  **Tooltip Table Modifications:**
    *   Removed the header row from the data table within the tooltip.
    *   Color-coded the 'Difference' values for "Pop. Phase 2+" and "Pop. Phase 3+": positive differences (increase in affected population) are shown in red, negative differences (decrease) in green.
    *   Total population difference remains in the default text color.

3.  **Tooltip Table Styling:**
    *   Further reduced the font size for the table content.
    *   Ensured that table data values are not bold, while indicator labels (e.g., "Total Pop.:") remain bold for clarity.

These changes aim to make the tooltips more informative and visually scannable within the compact country map windows. Noted new i18n keys: `better`, `worse`, `nowAnalyzed`, `previouslyAnalyzed`.